### PR TITLE
Allow Rails 5.2.+

### DIFF
--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email = 'sbartsch@tzi.org'
   s.files = %w[CHANGELOG MIT-LICENSE README.rdoc Rakefile authorization_rules.dist.rb garlic_example.rb init.rb] + Dir['app/**/*.rb'] + Dir['app/**/*.erb'] + Dir['config/*'] + Dir['lib/*.rb'] + Dir['lib/**/*.rb'] + Dir['lib/tasks/*'] + Dir['test/*']
   s.homepage = 'http://github.com/stffn/declarative_authorization'
-  s.add_dependency('rails', '>= 4.1.0', '<= 5.2.0')
+  s.add_dependency('rails', '>= 4.1.0', '< 6')
   s.add_dependency('ruby_parser', '>= 3.6.6')
   s.add_development_dependency('test-unit')
 end

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5.2.0'
+gem 'rails', '~> 5.2'
 gem 'sqlite3'
 gem 'rdoc'
 gem 'rails-controller-testing'


### PR DESCRIPTION
Security issues mean Rails 5.2 point release is now 5.2.1.1
Change the dependencies to be more permissive about Rails versions
[CVE-2018-16476] Broken Access Control vulnerability in Active Job
[CVE-2018-16477] Bypass vulnerability in Active Storage