### PR TITLE
Fixes request_with to use Hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ rdoc
 gemfiles/*.lock
 log/*
 *.sublime*
-
-
+.ruby-version
+.ruby-gemset
+.idea
+Gemfile
+Gemfile.lock

--- a/lib/declarative_authorization/maintenance.rb
+++ b/lib/declarative_authorization/maintenance.rb
@@ -181,9 +181,9 @@ module Authorization
       session = session.merge(user: user, user_id: user && user.id)
       with_user(user) do
         if xhr
-          xhr method, action, params, session, flash
+          xhr method, action, params: params, session: session, flash: flash
         else
-          send method, action, params, session, flash
+          send method, action, params: params, session: session, flash: flash
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,7 @@ class MockDataObject
 end
 
 class MockUser < MockDataObject
+  attr_accessor :id
   def initialize(*roles)
     options = roles.last.is_a?(::Hash) ? roles.pop : {}
     super({ role_symbols: roles, login: hash }.merge(options))


### PR DESCRIPTION
We use get_with, post_with etc extensively in our tests. Those tests failed because the interface to get, post etc now expects a hash. This pull request fixes maintenance.rb and includes a test for it.