### PR TITLE
remove auth_dsl_file '.freeze' so that Engines can also load auth info

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -20,7 +20,12 @@ module Authorization
   # The exception is raised to ensure that the entire rule is invalidated.
   class NilAttributeValueError < AuthorizationError; end
 
-  AUTH_DSL_FILES = [Pathname.new(Rails.root || '').join('config', 'authorization_rules.rb').to_s].freeze unless defined? AUTH_DSL_FILES
+  # although .freeze is a good idea, unfortunately this breaks when engines
+  # add information after 'AUTH_DSL_FILES' is defined by rails core
+  AUTH_DSL_FILES  = [ Pathname.new(Rails.root || '')
+                              .join('config', 'authorization_rules.rb')
+                              .to_s
+                    ] unless defined? AUTH_DSL_FILES
 
   # Controller-independent method for retrieving the current user.
   # Needed for model security where the current controller is not available.


### PR DESCRIPTION
This change make declarative_authorization (rails 5) version Engine compatible.  

While '.freeze' is a good idea on the AUTH_DSL_FILES constant, it prevents Engines from loading supplimental information after the Rails Core has been loaded.